### PR TITLE
Fix yarn build when docker container is started

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
       - "${DEV_SERVER_PORT:-8080}:8080"
     volumes:
       - .:/srv/app
-    command: sh -c "yarn install && yarn dev-server --host=0.0.0.0"
+    command: sh -c "yarn install && yarn watch"
 ###> doctrine/doctrine-bundle ###
   database:
     image: postgres:${POSTGRES_VERSION:-14}-alpine


### PR DESCRIPTION
En fait de ce que j'ai compris le yarn dev-server il va build sur un server externe, c'est pour ça qu'on a pas les fichiers en local. 
Je vois pas trop l'intérêt pour l'instant j'ai remis le yarn watch.